### PR TITLE
Add Odelia town with building interiors and camera system

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,236 +1,15 @@
 # main.py
-# Pixel Adventures — Flow: Title -> Class Select -> Game -> Title
+# Pixel Adventures — Flow: Title -> Class Select -> Odelia -> Title
 
 import sys
 import pygame
 import title_screen
 import class_select
 import opening_sequence
+import odelia
 
 VIRTUAL_SIZE = title_screen.VIRTUAL_SIZE
-CAPTION      = "Pixel Adventures"
-
-def _sprite_from_pattern(pattern, palette):
-    """Create a pygame Surface from a small ASCII art pattern.
-
-    `pattern` is a list of equal-length strings where each character maps to a
-    color in `palette`. The character `.` represents transparency.
-    """
-    height = len(pattern)
-    width = len(pattern[0]) if height else 0
-    surf = pygame.Surface((width, height), pygame.SRCALPHA)
-    for y, row in enumerate(pattern):
-        for x, ch in enumerate(row):
-            if ch == '.':
-                continue
-            surf.set_at((x, y), palette[ch])
-    return surf
-
-def _player_sprite_for(cid, color):
-    """Return a small pixel-art Surface for the given class id."""
-    if cid == "knight":
-        pattern = [
-            "..OOOO..",
-            ".OHHHHO.",
-            ".OHFFHO.",
-            ".OHEEHO.",
-            ".OHHHHO.",
-            ".OHCCHO.",
-            ".OHCCHO.",
-            ".OHHHHO.",
-            ".OH..HO.",
-            ".OH..HO.",
-            ".OH..HO.",
-            "..O..O..",
-        ]
-        palette = {
-            'O': (30, 30, 70),       # outline
-            'H': (170, 170, 190),    # armor
-            'F': (255, 220, 180),    # face
-            'E': (255, 255, 255),    # eyes
-            'C': color,              # class accent
-        }
-        return _sprite_from_pattern(pattern, palette)
-
-    if cid == "black_mage":
-        pattern = [
-            "..OOOO..",
-            ".OHHHHO.",
-            "OHHHHHHO",
-            "OHHHHHHO",
-            ".OkEEkO.",
-            ".OkkkkO.",
-            ".OCAACO.",
-            ".OCAACO.",
-            ".OCAACO.",
-            ".OCAACO.",
-            ".OCAACO.",
-            "..O..O..",
-        ]
-        palette = {
-            'O': (30, 30, 70),       # outline
-            'H': (40, 40, 70),       # hat
-            'k': (0, 0, 0),          # face shadow
-            'E': (255, 255, 255),    # eyes
-            'C': (30, 30, 90),       # robe
-            'A': color,              # accent trim
-        }
-        return _sprite_from_pattern(pattern, palette)
-
-    if cid == "white_mage":
-        pattern = [
-            "..OOOO..",
-            ".OHHHHO.",
-            "OHFFFFHO",
-            "OHFEEFHO",
-            ".OHHHHO.",
-            ".OWAWWO.",
-            ".OWAWWO.",
-            ".OAAAAO.",
-            ".OWAWWO.",
-            ".OWAWWO.",
-            ".OWAWWO.",
-            "..O..O..",
-        ]
-        palette = {
-            'O': (30, 30, 70),       # outline
-            'H': color,              # hood color
-            'F': (255, 220, 190),    # face
-            'E': (0, 0, 0),          # eyes
-            'W': (240, 240, 240),    # robe
-            'A': (200, 40, 40),      # red cross accent
-        }
-        return _sprite_from_pattern(pattern, palette)
-
-    # fallback simple block if class unknown
-    surf = pygame.Surface((8, 8))
-    surf.fill(color)
-    return surf
-
-def run_game(screen, clock, chosen_class):
-    vw, vh = VIRTUAL_SIZE
-    game_surf = pygame.Surface(VIRTUAL_SIZE)
-
-    # Use class stats
-    stats = chosen_class["stats"]
-    color = chosen_class["color"]
-    name  = chosen_class["name"]
-
-    # Build player sprite for this class
-    sprite = _player_sprite_for(chosen_class["id"], color)
-
-    base_speed = 60
-    speed      = base_speed * stats.get("spd_mult", 1.0)
-    magnet     = stats.get("magnet", 12)
-    special    = 0.0
-    special_rate = stats.get("special_rate", 1.0)
-
-    # player rect & simple walls
-    player = pygame.Rect(vw//2 - 4, vh//2 - 4, 8, 8)
-    walls = [pygame.Rect(20, 40, 216, 6), pygame.Rect(40, 88, 176, 6)]
-
-    # coins
-    coins = [pygame.Rect(16 + i*24, 24 + (i%3)*18, 4, 4) for i in range(7)]
-    score = 0
-
-    # HUD font
-    font = pygame.font.Font(None, 14)
-    big  = pygame.font.Font(None, 18)
-
-    # small helper
-    def attract_coin(c):
-        # pull coins toward player if within "magnet" radius
-        pc = pygame.Vector2(player.center)
-        cc = pygame.Vector2(c.center)
-        v = pc - cc
-        dist = v.length()
-        if dist < magnet and dist > 0:
-            step = max(1.0, dist * 0.12)  # proportional pull
-            move = v.normalize() * step
-            c.x += int(round(move.x))
-            c.y += int(round(move.y))
-
-    # For Black Mage: extra special on coin pickup (simple perk)
-    def on_coin_pickup():
-        nonlocal special
-        if chosen_class["id"] == "black_mage":
-            special = min(100.0, special + 8)
-
-    while True:
-        dt = clock.tick(60) / 1000.0
-
-        for e in pygame.event.get():
-            if e.type == pygame.QUIT: return "quit"
-            if e.type == pygame.KEYDOWN and e.key == pygame.K_ESCAPE:
-                return "title"
-
-        # input
-        keys = pygame.key.get_pressed()
-        move = pygame.Vector2(
-            (keys[pygame.K_RIGHT] or keys[pygame.K_d]) - (keys[pygame.K_LEFT] or keys[pygame.K_a]),
-            (keys[pygame.K_DOWN]  or keys[pygame.K_s]) - (keys[pygame.K_UP]   or keys[pygame.K_w])
-        )
-        if move.length_squared() > 0:
-            move = move.normalize()
-        vel = move * speed * dt
-
-        # movement + wall collision
-        player.x += int(round(vel.x))
-        for w in walls:
-            if player.colliderect(w):
-                if vel.x > 0: player.right = w.left
-                elif vel.x < 0: player.left = w.right
-        player.y += int(round(vel.y))
-        for w in walls:
-            if player.colliderect(w):
-                if vel.y > 0: player.bottom = w.top
-                elif vel.y < 0: player.top = w.bottom
-        player.clamp_ip(pygame.Rect(0, 0, vw, vh))
-
-        # coins
-        for c in coins[:]:
-            attract_coin(c)
-            if player.colliderect(c):
-                coins.remove(c)
-                score += 1
-                on_coin_pickup()
-
-        # Special meter passive fill (differs by class)
-        special = min(100.0, special + 12.0 * special_rate * dt)
-
-        # draw
-        game_surf.fill((12, 12, 18))
-        for y in range(0, vh, 8):
-            pygame.draw.line(game_surf, (18, 18, 26), (0, y), (vw, y))
-        for x in range(0, vw, 8):
-            pygame.draw.line(game_surf, (18, 18, 26), (x, 0), (x, vh))
-
-        for w in walls:
-            pygame.draw.rect(game_surf, (60, 60, 110), w)
-            pygame.draw.rect(game_surf, (20, 20, 50), w.inflate(2, 2), 1)
-
-        for c in coins:
-            pygame.draw.rect(game_surf, (255, 208, 52), c)
-            game_surf.set_at((c.centerx, c.top-1), (255, 255, 140))
-
-        # player sprite
-        sprite_rect = sprite.get_rect(center=player.center)
-        game_surf.blit(sprite, sprite_rect)
-
-        # HUD
-        hud_l = big.render(name, False, (230, 230, 230))
-        game_surf.blit(hud_l, (4, 4))
-        hud_r = font.render(f"Score: {score}", False, (200, 200, 200))
-        game_surf.blit(hud_r, (vw - hud_r.get_width() - 4, 6))
-
-        # Special bar
-        pygame.draw.rect(game_surf, (40, 40, 70), (4, vh - 10, vw - 8, 6), 1)
-        fill_w = int((vw - 10) * (special / 100.0))
-        pygame.draw.rect(game_surf, (120, 220, 255), (5, vh - 9, fill_w, 4))
-
-        # scale
-        pygame.transform.scale(game_surf, screen.get_size(), screen)
-        pygame.display.flip()
+CAPTION = "Pixel Adventures"
 
 def main():
     pygame.init()
@@ -241,20 +20,24 @@ def main():
     while True:
         # Title
         r = title_screen.run(screen, clock, VIRTUAL_SIZE)
-        if r == "quit": break
+        if r == "quit":
+            break
 
         # Class Select
         choice = class_select.run(screen, clock, VIRTUAL_SIZE)
-        if choice in ("quit", "back"):  # back returns to title, quit exits
-            if choice == "quit": break
-            else: continue
+        if choice in ("quit", "back"):
+            if choice == "quit":
+                break
+            else:
+                continue
 
-        # Opening battle sequence
+        # Opening sequence (battle/introduction)
         opening_sequence.run(screen, clock, VIRTUAL_SIZE)
 
-        # Game
-        r = run_game(screen, clock, choice)
-        if r == "quit": break
+        # Odelia town
+        r = odelia.run(screen, clock, choice, VIRTUAL_SIZE)
+        if r == "quit":
+            break
         # if "title", loop restarts at title
 
     pygame.quit()

--- a/odelia.py
+++ b/odelia.py
@@ -1,0 +1,236 @@
+# odelia.py
+"""Opening town: Odelia.
+
+This module implements a simple overworld town with multiple buildings. Each
+building has a door that lets the player enter an interior room. The camera
+follows the player around the town, scrolling the view when the player moves
+close to the edges of the screen.
+"""
+
+import pygame
+from typing import List
+
+VIRTUAL_SIZE = (256, 144)
+
+# --- player sprite helpers --------------------------------------------------
+
+def _sprite_from_pattern(pattern, palette):
+    """Create a pygame Surface from a small ASCII art pattern."""
+    height = len(pattern)
+    width = len(pattern[0]) if height else 0
+    surf = pygame.Surface((width, height), pygame.SRCALPHA)
+    for y, row in enumerate(pattern):
+        for x, ch in enumerate(row):
+            if ch == '.':
+                continue
+            surf.set_at((x, y), palette[ch])
+    return surf
+
+
+def _player_sprite_for(cid, color):
+    """Return a small pixel-art Surface for the given class id."""
+    if cid == "knight":
+        pattern = [
+            "..OOOO..",
+            ".OHHHHO.",
+            ".OHFFHO.",
+            ".OHEEHO.",
+            ".OHHHHO.",
+            ".OHCCHO.",
+            ".OHCCHO.",
+            ".OHHHHO.",
+            ".OH..HO.",
+            ".OH..HO.",
+            ".OH..HO.",
+            "..O..O..",
+        ]
+        palette = {
+            'O': (30, 30, 70),       # outline
+            'H': (170, 170, 190),    # armor
+            'F': (255, 220, 180),    # face
+            'E': (255, 255, 255),    # eyes
+            'C': color,              # class accent
+        }
+        return _sprite_from_pattern(pattern, palette)
+
+    if cid == "black_mage":
+        pattern = [
+            "..OOOO..",
+            ".OHHHHO.",
+            "OHHHHHHO",
+            "OHHHHHHO",
+            ".OkEEkO.",
+            ".OkkkkO.",
+            ".OCAACO.",
+            ".OCAACO.",
+            ".OCAACO.",
+            ".OCAACO.",
+            ".OCAACO.",
+            "..O..O..",
+        ]
+        palette = {
+            'O': (30, 30, 70),       # outline
+            'H': (40, 40, 70),       # hat
+            'k': (0, 0, 0),          # face shadow
+            'E': (255, 255, 255),    # eyes
+            'C': (30, 30, 90),       # robe
+            'A': color,              # accent trim
+        }
+        return _sprite_from_pattern(pattern, palette)
+
+    if cid == "white_mage":
+        pattern = [
+            "..OOOO..",
+            ".OHHHHO.",
+            "OHFFFFHO",
+            "OHFEEFHO",
+            ".OHHHHO.",
+            ".OWAWWO.",
+            ".OWAWWO.",
+            ".OAAAAO.",
+            ".OWAWWO.",
+            ".OWAWWO.",
+            ".OWAWWO.",
+            "..O..O..",
+        ]
+        palette = {
+            'O': (30, 30, 70),       # outline
+            'H': color,              # hood color
+            'F': (255, 220, 190),    # face
+            'E': (0, 0, 0),          # eyes
+            'W': (240, 240, 240),    # robe
+            'A': (200, 40, 40),      # red cross accent
+        }
+        return _sprite_from_pattern(pattern, palette)
+
+    surf = pygame.Surface((8, 8))
+    surf.fill(color)
+    return surf
+
+# --- Town data --------------------------------------------------------------
+
+WORLD_W, WORLD_H = 480, 360
+
+
+def _make_buildings() -> List[dict]:
+    buildings = []
+    rows, cols = 3, 4
+    w, h = 60, 60
+    for r in range(rows):
+        for c in range(cols):
+            bx = 40 + c * 100
+            by = 40 + r * 100
+            rect = pygame.Rect(bx, by, w, h)
+            solid = pygame.Rect(bx, by, w, h - 8)
+            door = pygame.Rect(bx + w // 2 - 8, by + h - 8, 16, 8)
+            interior_size = (160, 120)
+            interior_door = pygame.Rect(interior_size[0]//2 - 8, interior_size[1] - 8, 16, 8)
+            buildings.append({
+                "rect": rect,
+                "solid": solid,
+                "door": door,
+                "interior": {"size": interior_size, "door": interior_door},
+            })
+    return buildings
+
+# --- Main loop --------------------------------------------------------------
+
+def run(screen, clock, chosen_class, virtual_size=VIRTUAL_SIZE):
+    """Run the Odelia town scene."""
+    vw, vh = virtual_size
+    game_surf = pygame.Surface(virtual_size)
+
+    # Player setup
+    sprite = _player_sprite_for(chosen_class["id"], chosen_class["color"])
+    stats = chosen_class["stats"]
+    speed = 60 * stats.get("spd_mult", 1.0)
+    player = pygame.Rect(WORLD_W // 2 - 4, WORLD_H // 2 - 4, 8, 8)
+
+    buildings = _make_buildings()
+
+    mode = "town"  # or "interior"
+    current = None
+
+    while True:
+        dt = clock.tick(60) / 1000.0
+        for e in pygame.event.get():
+            if e.type == pygame.QUIT:
+                return "quit"
+            if e.type == pygame.KEYDOWN and e.key == pygame.K_ESCAPE:
+                return "title"
+
+        keys = pygame.key.get_pressed()
+        move = pygame.Vector2(
+            (keys[pygame.K_RIGHT] or keys[pygame.K_d]) - (keys[pygame.K_LEFT] or keys[pygame.K_a]),
+            (keys[pygame.K_DOWN] or keys[pygame.K_s]) - (keys[pygame.K_UP] or keys[pygame.K_w])
+        )
+        if move.length_squared() > 0:
+            move = move.normalize()
+        vel = move * speed * dt
+
+        if mode == "town":
+            # movement and collision
+            player.x += int(round(vel.x))
+            for b in buildings:
+                if player.colliderect(b["solid"]):
+                    if vel.x > 0: player.right = b["solid"].left
+                    elif vel.x < 0: player.left = b["solid"].right
+            player.y += int(round(vel.y))
+            for b in buildings:
+                if player.colliderect(b["solid"]):
+                    if vel.y > 0: player.bottom = b["solid"].top
+                    elif vel.y < 0: player.top = b["solid"].bottom
+            player.clamp_ip(pygame.Rect(0, 0, WORLD_W, WORLD_H))
+
+            # door entry
+            for b in buildings:
+                if player.colliderect(b["door"]):
+                    mode = "interior"
+                    current = b
+                    d = b["interior"]["door"]
+                    size = b["interior"]["size"]
+                    player = pygame.Rect(d.centerx - 4, d.bottom - 12, 8, 8)
+                    interior_rect = pygame.Rect(0, 0, *size)
+                    break
+
+            # camera
+            cam_x = player.centerx - vw // 2
+            cam_y = player.centery - vh // 2
+            cam_x = max(0, min(cam_x, WORLD_W - vw))
+            cam_y = max(0, min(cam_y, WORLD_H - vh))
+
+            # draw town
+            game_surf.fill((80, 170, 80))
+            for b in buildings:
+                r = b["rect"]
+                pygame.draw.rect(game_surf, (160, 110, 60), (r.x - cam_x, r.y - cam_y, r.w, r.h))
+                d = b["door"]
+                pygame.draw.rect(game_surf, (100, 70, 40), (d.x - cam_x, d.y - cam_y, d.w, d.h))
+            sprite_rect = sprite.get_rect(center=(player.centerx - cam_x, player.centery - cam_y))
+            game_surf.blit(sprite, sprite_rect)
+
+        else:  # interior
+            size = current["interior"]["size"]
+            interior_rect = pygame.Rect(0, 0, *size)
+
+            player.x += int(round(vel.x))
+            player.y += int(round(vel.y))
+            player.clamp_ip(interior_rect)
+
+            d = current["interior"]["door"]
+            if player.colliderect(d):
+                # exit to town
+                mode = "town"
+                px = current["door"].centerx - 4
+                py = current["door"].bottom
+                player = pygame.Rect(px, py, 8, 8)
+                current = None
+            game_surf.fill((180, 180, 180))
+            pygame.draw.rect(game_surf, (100, 70, 40), d)
+            sprite_rect = sprite.get_rect(center=player.center)
+            game_surf.blit(sprite, sprite_rect)
+
+        pygame.transform.scale(game_surf, screen.get_size(), screen)
+        pygame.display.flip()
+
+# End of odelia.py


### PR DESCRIPTION
## Summary
- Introduce Odelia town module with a scrolling overworld, ~12 buildings, and enterable interiors
- Add player-following camera and door transitions between town and interior rooms
- Update main flow to launch the Odelia scene after the opening sequence

## Testing
- `python -m py_compile main.py odelia.py title_screen.py class_select.py opening_sequence.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcd59c6458832bbf12ff51abe16732